### PR TITLE
added German translation for "today" Text

### DIFF
--- a/locales.js
+++ b/locales.js
@@ -130,7 +130,9 @@ const locales = {
       `Oktober`,
       `November`,
       `Dezember`
-    ]
+    ],
+    today: `Heute`,
+    format: `DD.MM.YYYY`
   },
   /* Dutch */
   'nl_nl-NL_nl-BE': {


### PR DESCRIPTION
Hello, @jcgertig, I've added a German translation for the today-Text, as this was somehow missing, while months and days have been translated correctly. 